### PR TITLE
Migrate the Code Style Checks to Pester 5

### DIFF
--- a/AppVeyor/Install.ps1
+++ b/AppVeyor/Install.ps1
@@ -6,8 +6,7 @@ $packageProvider = Install-PackageProvider -Name NuGet -Force
 Write-Host " - NuGet version '$($packageProvider.version)'"
 
 Write-Host ' - Pester'
-#TODO: Migrate to Pester 5, it's cool!
-Install-Module -Name Pester -MaximumVersion 4.9.9 -Repository PSGallery -Force
+Install-Module -Name Pester -Repository PSGallery -Force
 
 Write-Host ' - PSScriptAnalyzer'
 Install-Module PSScriptAnalyzer -Repository PSGallery -Force

--- a/PSToggl/PSToggl.Tests.ps1
+++ b/PSToggl/PSToggl.Tests.ps1
@@ -2,7 +2,7 @@ $moduleName = "PSToggl" #$env:ModuleName
 $PSVersion = $PSVersionTable.PSVersion.Major
 $repository = Resolve-Path "$PSScriptRoot\.."
 $moduleRoot = "$repository\$moduleName"
-$scripts = Get-ChildItem $repository -Filter "*.ps1" -Recurse | Where-Object {$_.name -NotMatch "Tests.ps1"}
+$scripts = Get-ChildItem $repository -Filter "*.ps1" -Recurse | Where-Object { $_.name -NotMatch "Tests.ps1" }
 $modules = Get-ChildItem $repository -Filter "*.psm1" -Recurse
 $rules = Get-ScriptAnalyzerRule
 $appveyorFile = "$repository\appveyor.yml"
@@ -10,23 +10,33 @@ $appveyorFile = "$repository\appveyor.yml"
 Describe "General code style compliance" {
     foreach ($module in $modules) {
         Context "Module '$($module.FullName)'" {
-            foreach ($rule in $rules) {
-                It "passes the PSScriptAnalyzer Rule $rule" {
-                    (Invoke-ScriptAnalyzer -Path $module.FullName -IncludeRule $rule.RuleName ).Count | Should Be 0
-                }
+            $cases = @()
+            #TODO: Find  a way to specifically supress that only for runtime created script blocks
+            foreach ($rule in $rules | Where-Object {$_.RuleName -ne "PSReviewUnusedParameter"}) {
+                $cases += @{module = $module; rule = $rule }
+            }
+            It "passes PSScriptAnalyzer check" -TestCases $cases {
+                param($module, $rule)
+                $result = Invoke-ScriptAnalyzer -Path $module.FullName -IncludeRule $rule.RuleName
+                $result.Message | ? { $_ } | % { Write-Host "$_ Rule: $($rule.RuleName)" }
+                $result.Count | Should -Be 0
             }
         }
     }
 
     foreach ($Script in $scripts) {
         Context "Script '$($script.FullName)'" {
-            foreach ($rule in $rules) {
-                It "passes the PSScriptAnalyzer Rule $rule" {
-                    if (-not ($module.BaseName -match "AppVeyor") -and -not ($rule.Rulename -eq "PSAvoidUsingWriteHost") ) {
-                        $result = Invoke-ScriptAnalyzer -Path $script.FullName -IncludeRule $rule.RuleName
-                        $result.Message | ? {$_} | % { Write-Host $_ }
-                        $result.Count | Should Be 0
-                    }
+            $cases = @()
+            #TODO: Find  a way to specifically supress that only for runtime created script blocks
+            foreach ($rule in $rules | Where-Object {$_.RuleName -ne "PSReviewUnusedParameter"}) {
+                $cases += @{module = $module; rule = $rule; script = $Script}
+            }
+            It "passes PSScriptAnalyzer check" -TestCases $cases {
+                param($module, $rule, $script)
+                if (-not ($module.BaseName -match "AppVeyor") -and -not ($rule.Rulename -eq "PSAvoidUsingWriteHost") ) {
+                    $result = Invoke-ScriptAnalyzer -Path $script.FullName -IncludeRule $rule.RuleName
+                    $result.Message | ? { $_ } | % { Write-Host "$_ Rule: $($rule.RuleName)" }
+                    $result.Count | Should -Be 0
                 }
             }
         }
@@ -78,13 +88,13 @@ Describe "$moduleName on PowerShell $PSVersion" {
 
     Context "Testing Environment" {
         # Public tests
-        Get-ChildItem -Path "$moduleRoot\Public" -Filter "*.ps1" -Recurse | Where-Object -FilterScript {$_.Name -notlike "*.Tests.ps1"} | ForEach-Object {
+        Get-ChildItem -Path "$moduleRoot\Public" -Filter "*.ps1" -Recurse | Where-Object -FilterScript { $_.Name -notlike "*.Tests.ps1" } | ForEach-Object {
             It "Includes a test for $($_.Name)" {
                 $_.FullName -replace ".ps1", ".Tests.ps1" -replace "PSToggl\\Public", "Tests\PSToggl\Public" | Should Exist
             }
         }
         # Private tests
-        Get-ChildItem -Path "$moduleRoot\Private" -Filter "*.ps1" -Recurse | Where-Object -FilterScript {$_.Name -notlike "*.Tests.ps1"} | ForEach-Object {
+        Get-ChildItem -Path "$moduleRoot\Private" -Filter "*.ps1" -Recurse | Where-Object -FilterScript { $_.Name -notlike "*.Tests.ps1" } | ForEach-Object {
             It "Includes a test for $($_.Name)" {
                 $_.FullName -replace ".ps1", ".Tests.ps1" -replace "PSToggl\\Private", "Tests\PSToggl\Private" | Should Exist
             }


### PR DESCRIPTION
In order to get Pester 5 running, several changes are required.
Variables have to be passed by -TestCases, `Should` Verbs are parameters
and so on

Relates to #9